### PR TITLE
Only select Earth coordinates

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -225,6 +225,7 @@ $(document).ready(function() {
                         ?statement psv:P625 ?coords . 
                         ?coords wikibase:geoLatitude ?lat . 
                         ?coords wikibase:geoLongitude ?lon . 
+                        ?coords wikibase:geoGlobe wd:Q2 .
                         ${restriction} 
                 } LIMIT 1000
             } 


### PR DESCRIPTION
Wikidata contains coordinates for other globes such as Mars and Venus. This makes sure it only selects Earth coordinates.

(We got https://www.wikidata.org/wiki/Q1473902, a volcano on Venus, while playing this during a Wikidata event :grin:)