### PR TITLE
Remove circles of latitude/longitude

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -225,6 +225,7 @@ $(document).ready(function() {
                         ?statement psv:P625 ?coords . 
                         ?coords wikibase:geoLatitude ?lat . 
                         ?coords wikibase:geoLongitude ?lon . 
+                        ?coords wikibase:geoGlobe wd:Q2 .
                         ${restriction} 
                 } LIMIT 1000
             } 

--- a/js/app.js
+++ b/js/app.js
@@ -227,6 +227,8 @@ $(document).ready(function() {
                         ?coords wikibase:geoLongitude ?lon . 
                         ?coords wikibase:geoGlobe wd:Q2 .
                         ${restriction} 
+                        MINUS { ?item wdt:P31 wd:Q146591. }
+                        MINUS { ?item wdt:P31 wd:Q32099. }
                 } LIMIT 1000
             } 
             SERVICE wikibase:label { bd:serviceParam wikibase:language "en,de". } 


### PR DESCRIPTION
These have coordinate statements (points), but really represent great circles (or halves thereof), and it doesn’t make sense to calculate a score based on the distance from their coordinate statement where one of the coordinates is actually meaningless. Just filter them out. (Their images, if they have any, are of limited usefulness too.)

----

Seen at 38C3:
![IMG_20241228_173714490](https://github.com/user-attachments/assets/6c55caca-6bd9-4819-8bef-227cb917fe93)

Also includes #10 (cc @nikkiwd).