### PR TITLE
Balance and smoothness

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -212,7 +212,7 @@ $(document).ready(function() {
         if (params && params.match(/^Q\d+$/)) {
             var restriction = "?item wdt:P31 wd:"+params+".";
         } else {
-            var restriction = "";
+            var restriction = "?item wdt:P31 ?prop . FILTER(?prop NOT IN (wd:Q921099, wd:Q7379880))";
         }
 
         const query = `

--- a/js/minimap.js
+++ b/js/minimap.js
@@ -3,9 +3,14 @@
 //
 
 function mminitialize() {
-    mymap = L.map("miniMap");
+    mymap = L.map("miniMap", {
+	    zoomSnap: .01,
+	    zoomDelta: 1,
+	    wheelPxPerZoomLevel: 150,
+	    wheelDebounceTime: 100
+    });
 
-    mymap.setView([30, 10], 1);
+    mymap.setView([30, 10], 1)
 
     L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
         attribution: 'Map data © <a href="http://openstreetmap.org">OpenStreetMap</a> contributors',


### PR DESCRIPTION
I noticed that almost every other photo was of a Swiss boundary stone. There were also a lot of runic inscriptions. These are easy to guess and repetitive, so I added a default restriction which does not allow them to be chosen.

I also added a fractional zoomSnap to the leaflet minimap which makes the zooming behavior a little better.